### PR TITLE
Fix rubocop violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,6 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
     - 'attributes/**/*.rb'
+  ExcludedMethods:
+    - action
+    - converge_by

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,8 @@ Metrics/LineLength:
 
 Metrics/AbcSize:
   Max: 25
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+    - 'attributes/**/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,14 @@
 
 source 'http://rubygems.org'
 
+gem 'berkshelf'
+gem 'chef'
 gem 'chefspec'
+gem 'foodcritic'
+gem 'rake'
 gem 'rspec'
 gem 'rspec-core'
 gem 'rspec-expectations'
 gem 'rspec-mocks'
-gem 'chef'
-gem 'foodcritic'
 gem 'rubocop'
-gem 'rake'
-gem 'berkshelf'
 gem 'stove'

--- a/attributes/vs2017.rb
+++ b/attributes/vs2017.rb
@@ -20,7 +20,8 @@
 #
 
 # Currently you cannot change this, doing so will break the cookbook
-default['visualstudio']['2017']['install_dir'] = (ENV['ProgramFiles(x86)'] || 'C:\Program Files (x86)') + '\Microsoft Visual Studio 16.0'
+default['visualstudio']['2017']['install_dir'] =
+  (ENV['ProgramFiles(x86)'] || 'C:\Program Files (x86)') + '\Microsoft Visual Studio 16.0'
 default['visualstudio']['2017']['all'] = false
 default['visualstudio']['2017']['allWorkloads'] = false
 default['visualstudio']['2017']['includeRecommended'] = true
@@ -117,7 +118,7 @@ default['visualstudio']['2017']['enterprise']['checksum'] = ''
 default['visualstudio']['2017']['enterprise']['default_source'] = 'https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Enterprise&rel=15'
 
 # Defaults for the https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-enterprise
-default['visualstudio']['2017']['enterprise']['default_install_items'].tap do |h|  
+default['visualstudio']['2017']['enterprise']['default_install_items'].tap do |h|
   h['Microsoft.VisualStudio.Workload.CoreEditor']['selected'] = true
   h['Microsoft.VisualStudio.Workload.Azure']['selected'] = true
   h['Microsoft.VisualStudio.Workload.Data']['selected'] = true

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -29,7 +29,8 @@ module Visualstudio
     # Gets the version/edition ISO download URL or raises an error
     def source_download_url(version, edition)
       src = iso_source(version, edition)
-      assert_src_is_not_nil(src, version, edition) unless node['visualstudio'][version][edition]['installer_file'].empty?
+      assert_src_is_not_nil(src, version, edition) \
+        unless node['visualstudio'][version][edition]['installer_file'].empty?
       url = nil
       url = ::File.join(src, node['visualstudio'][version][edition]['filename']) unless src.empty?
       url
@@ -47,11 +48,10 @@ module Visualstudio
 
     # Fails the Chef run if the visualstudio download source is not set
     def assert_src_is_not_nil(src, version, edition)
-      if src.nil?
-        raise 'The ISO download source is empty! '\
-          "Set the node['visualstudio']['#{version}']['#{edition}']['source'] " \
-          'or node[\'visualstudio\'][\'source\'] attribute and run again!'
-      end
+      return unless src.nil?
+      raise 'The ISO download source is empty! '\
+        "Set the node['visualstudio']['#{version}']['#{edition}']['source'] " \
+        'or node[\'visualstudio\'][\'source\'] attribute and run again!'
     end
 
     def windows_package_is_installed?(package_name)

--- a/providers/edition.rb
+++ b/providers/edition.rb
@@ -135,21 +135,36 @@ def create_vs2010_unattend_file
 end
 
 def prepare_vs2017_options
-  visual_studio_attributes = node['visualstudio'][new_resource.version.to_s]
-
   setup_options = '--norestart --passive --wait'
-  setup_options << " --installPath \"#{new_resource.install_dir}\"" unless new_resource.install_dir.empty?
-  setup_options << ' --all' if visual_studio_attributes['all']
-  setup_options << ' --allWorkloads' if visual_studio_attributes['allWorkloads']
-  setup_options << ' --includeRecommended' if visual_studio_attributes['includeRecommended']
-  setup_options << ' --includeOptional' if visual_studio_attributes['includeOptional']
+  setup_options << prepare_vs2017_options_installpath
+  setup_options << prepare_vs2017_options_global
 
+  visual_studio_attributes = node['visualstudio'][new_resource.version.to_s]
   visual_studio_attributes[new_resource.edition.to_s]['default_install_items'].each do |key, attributes|
     next unless attributes['selected']
     setup_options << " --add #{key}"
   end
 
   setup_options
+end
+
+def prepare_vs2017_options_installpath
+  path_option = ''
+  path_option = " --installPath \"#{new_resource.install_dir}\"" unless new_resource.install_dir.empty?
+
+  path_option
+end
+
+def prepare_vs2017_options_global
+  visual_studio_attributes = node['visualstudio'][new_resource.version.to_s]
+
+  global_options = ''
+  global_options << ' --all' if visual_studio_attributes['all']
+  global_options << ' --allWorkloads' if visual_studio_attributes['allWorkloads']
+  global_options << ' --includeRecommended' if visual_studio_attributes['includeRecommended']
+  global_options << ' --includeOptional' if visual_studio_attributes['includeOptional']
+
+  global_options
 end
 
 def utf8_to_unicode(file_path)


### PR DESCRIPTION
Fixed rubocop violations (on rubocop 0.47.1) which seem to be a superset of the ones appveyor is caring about.  Hopefully having the BlockLength stuff in the config file won't upset the older rubocop!